### PR TITLE
Do not send Content-Type when type is unknown 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
-import http, { IncomingMessage, OutgoingMessage, ServerResponse } from 'http';
+import http, { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'http';
 import https from 'https';
 import { URL } from 'url';
 import { build, BuildOptions, BuildResult, Plugin } from 'esbuild';
@@ -172,11 +172,14 @@ export function createServer(
         return sendHtml(res, html);
       }
 
-      res.writeHead(200, {
-        'Content-Type': contentType,
+      const headers: OutgoingHttpHeaders = {
         'Content-Length': stat.size,
         'Cache-Control': 'no-store, must-revalidate',
-      });
+      };
+      if (contentType) {
+        headers['Content-Type'] = contentType;
+      }
+      res.writeHead(200, headers);
 
       // @ts-ignore – for some reason the types doesn't include this one
       const readStream = file.createReadStream({ autoClose: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
-import http, { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'http';
+import http, {
+  IncomingMessage,
+  OutgoingHttpHeaders,
+  ServerResponse,
+} from 'http';
 import https from 'https';
 import { URL } from 'url';
 import { build, BuildOptions, BuildResult, Plugin } from 'esbuild';

--- a/src/mime.ts
+++ b/src/mime.ts
@@ -123,7 +123,7 @@ export function getMimeType(filePath: string) {
     case 'webp':
       return 'image/webp';
     case 'ico':
-      return 'image/vnd.microsoft.icon'
+      return 'image/vnd.microsoft.icon';
     case 'appcache':
     case 'manifest':
       return 'text/cache-manifest';

--- a/src/mime.ts
+++ b/src/mime.ts
@@ -122,6 +122,8 @@ export function getMimeType(filePath: string) {
       return 'image/tiff';
     case 'webp':
       return 'image/webp';
+    case 'ico':
+      return 'image/vnd.microsoft.icon'
     case 'appcache':
     case 'manifest':
       return 'text/cache-manifest';


### PR DESCRIPTION
Also added support for .ico type.

Fixes https://github.com/oblador/esbuild-server/issues/2