### PR TITLE
Add repo and homepage info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "format": "prettier '{,src/,example/**/}*.{md,js,ts,json,html}' --write",
     "prepare": "npm run build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oblador/esbuild-server.git"
+  },
+  "homepage": "https://github.com/oblador/esbuild-server#readme",
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
So it appears in NPM and makes it easy to go to the repo on GitHub:

![image](https://user-images.githubusercontent.com/7104356/232561182-abdf4421-7a7b-4f8f-b6de-f0fc5181468c.png)

Would then look like this:

![image](https://user-images.githubusercontent.com/7104356/232561678-0d112502-6898-4ce1-88b4-7b1a243d2707.png)
