### PR TITLE
Prevent exiting on error connecting to proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,11 @@ export function createServer(
           }
         ),
         { end: true }
-      );
+      ).on('error', (err) => {
+        const msg = `Error connecting to the proxy via ${rewrite}`;
+        console.error(msg, err);
+        res.writeHead(500).write(msg);
+      });
     }
 
     // Stall request while rebuilding to not serve stale files

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ export function createServer(
       ).on('error', (err) => {
         const msg = `Error connecting to the proxy via ${rewrite}`;
         console.error(msg, err);
-        res.writeHead(500).write(msg);
+        res.writeHead(500, { 'Content-Type': 'text/plain' }).end(msg);
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ export function createServer(
       ).on('error', (err) => {
         const msg = `Error connecting to the proxy via ${rewrite}`;
         console.error(msg, err);
-        res.writeHead(500, { 'Content-Type': 'text/plain' }).end(msg);
+        res.writeHead(502, { 'Content-Type': 'text/plain' }).end(msg);
       });
     }
 


### PR DESCRIPTION
Instead of getting this error when the proxy is unavilable and exiting completely:

![image](https://user-images.githubusercontent.com/7104356/233980993-787fa198-f54f-4a7a-b146-e33a83bee4f0.png)

Get this error, but stay running:

![image](https://user-images.githubusercontent.com/7104356/233980802-6c839c2f-dd48-4f91-b431-2b9177c44132.png)

The error gets propagated to the original requester

![image](https://user-images.githubusercontent.com/7104356/233980694-5735948e-1421-4ba1-83c3-af22c33ed502.png)
